### PR TITLE
Disable fetch cache on `/thread/[threadId]` route

### DIFF
--- a/app/thread/[threadId]/page.tsx
+++ b/app/thread/[threadId]/page.tsx
@@ -5,6 +5,8 @@ import { getFormattedDate } from "@/lib/getFormattedDate";
 import { getPriority } from "@/lib/getPriority";
 import styles from "./page.module.css";
 
+export const fetchCache = "force-no-store"
+
 export default async function ThreadPage({
 	params,
 }: {


### PR DESCRIPTION
When adding the ability to reply to threads, the replies do not show up on the page until much later. That's because Next.js caches fetched data by default. Adding the `force-no-store` cache directive to the page fixes the issue.